### PR TITLE
Refactor before making changes to MemberPage

### DIFF
--- a/lib/member_page.rb
+++ b/lib/member_page.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+require 'scraped'
+
+class MemberPage < Scraped::HTML
+  field :birth_date do
+    date_from(cells.find { |t| t.include?('Datëlindja') })
+  end
+
+  field :birth_place do
+    cells.find(-> { ':' }) { |t| t.include?('Vendlindja') }.split(':', 2).last.tidy.sub(/\.$/, '')
+  end
+
+  field :area do
+    member.find(-> { ':' }) { |t| t.include? 'Qarku' }.split(':', 2).last.tidy.sub(/\.$/, '')
+  end
+
+  field :commissions do
+    groups.find(-> { '' }) { |t| t.include? 'Komisioni' }.tidy
+  end
+
+  private
+
+  def box
+    noko.css('.post-content')
+  end
+
+  def cells
+    box.xpath('.//td').map(&:text).map { |t| t.split("\n") }.flatten.map(&:tidy).compact.reject(&:empty?)
+  end
+
+  # TODO: cope with this being missing
+  def member_h
+    return if cells.empty?
+    cells.find_index { |t| t.start_with? 'Zgjedhur' }
+  end
+
+  # TODO: ...and this
+  def groups_h
+    cells.find_index { |t| t.start_with? 'Grupi' }
+  end
+
+  def member
+    return [] if member_h.nil?
+    cells[member_h.to_i + 1..(groups_h ? groups_h - 1 : -1)]
+  end
+
+  def groups
+    groups_h ? cells[groups_h + 1..-1] : []
+  end
+
+  def date_from(text)
+    return if text.to_s.tidy.empty?
+    Date.parse(text).to_s rescue ''
+  end
+end

--- a/lib/member_row.rb
+++ b/lib/member_row.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+require 'scraped'
+
+class MemberRow < Scraped::HTML
+  field :id do
+    noko.attr('class')[/post-(\d+)/, 1]
+  end
+
+  field :name do
+    noko.css('h2').text.tidy
+  end
+
+  field :party_id do
+    party_id_and_name.first
+  end
+
+  field :party do
+    party_id_and_name.last
+  end
+
+  field :email do
+    noko.css('a[href*="@"]/@href').text.sub('mailto:', '')
+  end
+
+  field :image do
+    noko.css('.fusion-image-wrapper img/@src').text
+  end
+
+  field :source do
+    noko.css('h2 a/@href').text
+  end
+
+  private
+
+  def party_id_and_name
+    noko.css('.fusion-portfolio-content h4').text.tidy.split(':', 2)
+  end
+end

--- a/lib/members_page.rb
+++ b/lib/members_page.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+require 'scraped'
+
+class MembersPage < Scraped::HTML
+  field :member_rows do
+    noko.css('.fusion-portfolio-post').map do |row|
+      fragment row => MemberRow
+    end
+  end
+
+  field :next_page do
+    noko.css('a.next/@href')
+  end
+end

--- a/scraper.rb
+++ b/scraper.rb
@@ -40,7 +40,7 @@ def scrape_list(url)
       image:    p.css('.fusion-image-wrapper img/@src').text,
       source:   p.css('h2 a/@href').text,
     }
-    data.merge! (scrape data[:source] => MemberPage).to_h
+    data.merge! (scrape data[:source] => MemberPage).to_h unless urls_to_skip.include? data[:source]
     # puts data.reject { |k, v| v.to_s.empty? }.sort_by { |k, v| k }.to_h
     ScraperWiki.save_sqlite(%i(id term), data)
   end
@@ -48,6 +48,14 @@ def scrape_list(url)
   unless (next_page = noko.css('a.next/@href')).empty?
     scrape_list next_page.text
   end
+end
+
+def urls_to_skip
+  [
+    'https://www.parlament.al/deputet/genc-ruli/',
+    'https://www.parlament.al/deputet/gramoz-ruci/',
+    'https://www.parlament.al/deputet/myqerem-tafaj/',
+  ]
 end
 
 ScraperWiki.sqliteexecute('DELETE FROM data') rescue nil

--- a/scraper.rb
+++ b/scraper.rb
@@ -12,42 +12,16 @@ require_rel 'lib'
 # OpenURI::Cache.cache_path = '.cache'
 require 'scraped_page_archive/open-uri'
 
-def noko_for(url)
-  Nokogiri::HTML(open(url).read)
-end
-
-def date_from(text)
-  return if text.to_s.tidy.empty?
-  Date.parse(text).to_s rescue ''
-end
-
 def scrape(h)
   url, klass = h.to_a.first
   klass.new(response: Scraped::Request.new(url: url).response)
 end
 
-def scrape_list(url)
-  noko = noko_for(url)
-  noko.css('.fusion-portfolio-post').each do |p|
-    party_id, party = p.css('.fusion-portfolio-content h4').text.tidy.split(':', 2)
-    data = {
-      id:       p.attr('class')[/post-(\d+)/, 1],
-      name:     p.css('h2').text.tidy,
-      party_id: party_id,
-      party:    party,
-      email:    p.css('a[href*="@"]/@href').text.sub('mailto:', ''),
-      term:     8,
-      image:    p.css('.fusion-image-wrapper img/@src').text,
-      source:   p.css('h2 a/@href').text,
-    }
-    data.merge! (scrape data[:source] => MemberPage).to_h unless urls_to_skip.include? data[:source]
-    # puts data.reject { |k, v| v.to_s.empty? }.sort_by { |k, v| k }.to_h
-    ScraperWiki.save_sqlite(%i(id term), data)
-  end
-
-  unless (next_page = noko.css('a.next/@href')).empty?
-    scrape_list next_page.text
-  end
+def member_rows(url, rows = nil)
+  members_page = (scrape url => MembersPage)
+  rows = rows.to_a + members_page.member_rows
+  return rows if members_page.next_page.empty?
+  member_rows(members_page.next_page.text, rows)
 end
 
 def urls_to_skip
@@ -58,5 +32,12 @@ def urls_to_skip
   ]
 end
 
+data = member_rows('http://www.parlament.al/atribut/deputet/').map(&:to_h)
+                                                              .map do |row|
+  row.merge!((scrape row[:source] => MemberPage).to_h) unless urls_to_skip.include? row[:source]
+  row.merge(term: 8)
+end
+
+# data.each { |d| puts d.reject { |k, v| v.to_s.empty? }.sort_by { |k, v| k }.to_h }
 ScraperWiki.sqliteexecute('DELETE FROM data') rescue nil
-scrape_list('http://www.parlament.al/atribut/deputet/')
+ScraperWiki.save_sqlite(%i(id term), data)


### PR DESCRIPTION
The scraper is currently pulling in broken data. Example:
```
:birth_place=>"10.12.1957. Vendlindja: Durrës
```

Some member pages cannot be scraped as the scraper cannot yet handle them.

As a step towards making changes to fix the scraper, this PR refactors the scraper for use with scraped.

The current logic breaks on some member pages. Previously, the scraper dealt with these pages by returning an empty `{}` from `scrape_person`.  In this PR, to avoid cluttering `MemberPage` with conditionals the scraper skips these pages. The URLs to be skipped have been hardcoded into the scraper.

The next step will be to make changes to the member page so that it can handle all members and capture data correctly.

Part of: https://github.com/everypolitician/everypolitician-data/issues/25290