### PR TITLE
Add scraper test Rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,11 +2,15 @@
 
 require 'rubocop/rake_task'
 require 'rake/testtask'
+require 'scraper_test'
 
 RuboCop::RakeTask.new
 
 Rake::TestTask.new do |t|
   t.test_files = FileList['test/**/*_test.rb']
 end
+
+ScraperTest::RakeTask.new.install_tasks
+task test: 'test:data'
 
 task default: %w[test rubocop]


### PR DESCRIPTION
This PR ensures that Rake runs checks against any yaml files in `tests\data` using `scraper_test` (https://github.com/everypolitician/scraper_test)

This is in preparation of https://github.com/everypolitician-scrapers/albania-kuvendi/pull/9 which will introduce changes.