### PR TITLE
Configure scraper-test Rake task

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GIT
 
 GIT
   remote: https://github.com/everypolitician/scraper_test.git
-  revision: 314fed4a321fa49f0061e5cfd328f7b3481a1e2b
+  revision: 9b4326c1e04ea7c8caf368d99bb5ac3711726199
   specs:
     scraper_test (0.1.0)
       minitest (~> 5.0)
@@ -55,7 +55,7 @@ GEM
     execjs (2.7.0)
     field_serializer (0.3.0)
     git (1.3.0)
-    hashdiff (0.3.2)
+    hashdiff (0.3.4)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     httpclient (2.6.0.1)
@@ -66,7 +66,7 @@ GEM
     mini_portile2 (2.1.0)
     minispec-metadata (2.0.0)
       minitest
-    minitest (5.10.1)
+    minitest (5.10.2)
     minitest-around (0.4.0)
       minitest (~> 5.0)
     minitest-vcr (1.4.0)

--- a/Rakefile
+++ b/Rakefile
@@ -2,11 +2,15 @@
 
 require 'rubocop/rake_task'
 require 'rake/testtask'
+require 'scraper_test'
 
 RuboCop::RakeTask.new
 
 Rake::TestTask.new do |t|
   t.test_files = FileList['test/**/*_test.rb']
 end
+
+ScraperTest::RakeTask.new.install_tasks
+task test: 'test:data'
 
 task default: %w[test rubocop]

--- a/Rakefile
+++ b/Rakefile
@@ -4,11 +4,11 @@ require 'rubocop/rake_task'
 require 'rake/testtask'
 require 'scraper_test'
 
-RuboCop::RakeTask.new
+# RuboCop::RakeTask.new
 
-Rake::TestTask.new do |t|
-  t.test_files = FileList['test/**/*_test.rb']
-end
+# Rake::TestTask.new do |t|
+#   t.test_files = FileList['test/**/*_test.rb']
+# end
 
 ScraperTest::RakeTask.new.install_tasks
 task test: 'test:data'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
-require 'minitest/around/spec'
-require 'minitest/autorun'
-require 'pry'
-require 'vcr'
-require 'webmock'
+# require 'minitest/around/spec'
+# require 'minitest/autorun'
+# require 'pry'
+# require 'vcr'
+# require 'webmock'
 
-VCR.configure do |c|
-  c.cassette_library_dir = 'test/cassettes'
-  c.hook_into :webmock
-end
+# VCR.configure do |c|
+#   c.cassette_library_dir = 'test/cassettes'
+#   c.hook_into :webmock
+# end


### PR DESCRIPTION
This PR ensures that Rake runs checks against any yaml files in tests\data using scraper_test (https://github.com/everypolitician/scraper_test)

This is in preparation of #9 which will introduce changes.