### PR TITLE
Add scraper_test task to Rake

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,8 +5,12 @@ require 'rake/testtask'
 
 RuboCop::RakeTask.new
 
+require 'scraper_test'
+ScraperTest::RakeTask.new.install_tasks
+
 Rake::TestTask.new do |t|
   t.test_files = FileList['test/**/*_test.rb']
 end
 
-task default: %w[test rubocop]
+task test: 'test:data'
+task default: %w[rubocop test]


### PR DESCRIPTION
This PR ensures that Rake runs checks against any yaml files in tests\data using scraper_test (https://github.com/everypolitician/scraper_test)

This is in preparation of #9 which will introduce changes.